### PR TITLE
Add aggregation for `g` for when MirroredVariable

### DIFF
--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -151,7 +151,8 @@ class WeightNorm(Wrapper):
           shape=(self.layer_depth,),
           initializer=initializers.get('ones'),
           dtype=self.layer.kernel.dtype,
-          trainable=True)
+          trainable=True,
+          aggregation=variable_scope.VariableAggregation.MEAN)
 
       with ops.control_dependencies([self.layer.g.assign(
           self._init_norm(self.layer.v))]):


### PR DESCRIPTION
Thanks for building this wrapper. I found it worked great in single gpu mode, when applied with a distributed strategy (tf.contrib.distribute.MirroredStrategy), tensorflow would complain with a message about needing an aggregation function for a MirroredVariable.

I believe this small change should fix that. The kernel norm `g` gets updated during the training loop so it needs explicit instructions on how to be aggregated across towers.